### PR TITLE
Handle unbounded Fletcher's penalty variable

### DIFF
--- a/src/FletcherPenaltyNLPSolver.jl
+++ b/src/FletcherPenaltyNLPSolver.jl
@@ -86,7 +86,13 @@ TODO:
 - Continue to explore the paper.
 - [Long term] Complemetarity constraints
 """
-function fps_solve(nlp::AbstractNLPModel, x0::AbstractVector{T} = nlp.meta.x0; kwargs...) where {T}
+function fps_solve(
+  nlp::AbstractNLPModel,
+  x0::AbstractVector{T} = nlp.meta.x0;
+  subsolver_verbose::Int=0,
+  lagrange_bound=1/sqrt(eps(T)),
+  kwargs...,
+) where {T}
   if !(nlp.meta.minimize)
     error("fps_solve only works for minimization problem")
   end
@@ -121,7 +127,7 @@ function fps_solve(nlp::AbstractNLPModel, x0::AbstractVector{T} = nlp.meta.x0; k
     # max_cntrs = Stopping.init_max_counters();
     kwargs...,
   )
-  stats = fps_solve(stp, meta)
+  stats = fps_solve(stp, meta; subsolver_verbose = subsolver_verbose, lagrange_bound = lagrange_bound)
   if ineq && stats.multipliers_L != []
     nnvar = nlp.model.meta.nvar
     # reshape the stats to fit the original problem
@@ -157,11 +163,16 @@ function fps_solve(nlp::AbstractNLPModel, x0::AbstractVector{T} = nlp.meta.x0; k
   return stats
 end
 
-function fps_solve(stp::NLPStopping; kwargs...)
+function fps_solve(
+  stp::NLPStopping;
+  subsolver_verbose::Int=0,
+  lagrange_bound=1/sqrt(eps(T)),
+  kwargs...,
+)
   T = eltype(stp.pb.meta.x0)
   meta = AlgoData(T; kwargs...)
 
-  return fps_solve(stp, meta)
+  return fps_solve(stp, meta; subsolver_verbose = subsolver_verbose, lagrange_bound = lagrange_bound)
 end
 
 include("algo.jl")

--- a/src/StoppingInterfacemod.jl
+++ b/src/StoppingInterfacemod.jl
@@ -101,13 +101,13 @@ export status_stopping_to_stats, stopping_to_stats
 ipopt(nlp) DOESN'T CHECK THE WRONG KWARGS, AND RETURN AN ERROR.
 ipopt(::NLPStopping)
 """
-function NLPModelsIpopt.ipopt(stp::NLPStopping; kwargs...)
+function NLPModelsIpopt.ipopt(stp::NLPStopping; subsolver_verbose::Int = 0, kwargs...)
 
   #xk = solveIpopt(stop.pb, stop.current_state.x)
   nlp = stp.pb
   stats = ipopt(
     nlp,
-    print_level = 0,
+    print_level = subsolver_verbose,
     tol = stp.meta.rtol,
     x0 = stp.current_state.x,
     max_iter = stp.meta.max_iter,
@@ -179,7 +179,7 @@ end
         maxit::Int = 0, #stp.meta.max_iter
         maxtime_real::Real = stp.meta.max_time,
         out_hints::Int = 0,
-        outlev::Int = 0, #1 to see everything
+        subsolver_verbose::Int = 0, #1 to see everything
         algorithm::Int = 0, # *New* 2
         ftol::Real = 1.0e-15, # *New*
         ftol_iters::Int = 5, # *New*
@@ -190,7 +190,7 @@ end
         @assert -1 ≤ convex ≤ 1
         @assert 1 ≤ hessopt ≤ 7
         @assert 0 ≤ out_hints ≤ 1
-        @assert 0 ≤ outlev ≤ 6
+        @assert 0 ≤ subsolver_verbose ≤ 6
         @assert 0 ≤ maxit
 
         nlp = stp.pb
@@ -213,7 +213,7 @@ end
           ftol_iters = ftol_iters,
           xtol = xtol,
           xtol_iters = xtol_iters,
-          outlev = outlev;
+          outlev = subsolver_verbose;
           kwargs...,
         )
         stats = NLPModelsKnitro.knitro!(nlp, solver)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -25,6 +25,8 @@ struct AlgoData{T <: Real}
   ρ_max::T
   ρ_update::T
   δ_0::T
+  δ_max::T
+  δ_update::T
   η_1::T
   η_update::T
 
@@ -53,6 +55,8 @@ function AlgoData(
   ρ_max::Real = 1 / eps(T),
   ρ_update::Real = T(2),
   δ_0::Real = √eps(T),
+  δ_max::Real = 1 / eps(T),
+  δ_update::Real = T(10),
   η_1::Real = zero(T),
   η_update::Real = one(T),
   yM::Real = typemax(T),
@@ -73,6 +77,8 @@ function AlgoData(
     ρ_max,
     ρ_update,
     δ_0,
+    δ_max,
+    δ_update,
     η_1,
     η_update,
     yM,

--- a/test/rank-deficient.jl
+++ b/test/rank-deficient.jl
@@ -1,22 +1,23 @@
 ################################################################################
-#
-# December 15, 2020: T.M.
-# This is a test on rank-deficient jacobian problems, following the discussion
-# in Section 9.4 of Estrin et al. (2020).
-#
-# Works well :).
-#
-# Comments:
-# Convergence of x is O(δ), so it should be small or converge to a small value.
-# How much does it help the least-square?
-#
-# Warning: ghjvprod and jth_hess not implemented for CUTEstModel,
-# so hessian_approx = 1 cannot be used.
-#
-################################################################################
-#using CUTEst, NLPModels, NLPModelsKnitro
+#=
+
+December 15, 2020: T.M.
+This is a test on rank-deficient jacobian problems, following the discussion
+in Section 9.4 of Estrin et al. (2020).
+
+Comments:
+Convergence of x is O(δ), so it should be small or converge to a small value.
+How much does it help the least-square?
+
+Warning: ghjvprod and jth_hess not implemented for CUTEstModel,
+so hessian_approx = 1 cannot be used.
+
+using ADNLPModels, CUTEst, NLPModels, NLPModelsIpopt, Test, LinearAlgebra
 #This package
-#using FletcherPenaltyNLPSolver
+using FletcherPenaltyNLPSolver
+using Pkg; Pkg.update()
+=#
+################################################################################
 
 @testset "Rank-deficient HS61" begin
   nlp = ADNLPModel(
@@ -26,24 +27,21 @@
     zeros(2),
     zeros(2),
   )
-  #=
-    stats = fps_solve(nlp, nlp.meta.x0, 
-                                    σ_0 = 1e3, ρ_0 = 1e3, δ_0 = 1e-2, 
-                                    hessian_approx = 1, #error with hessian_approx = 1
-                                    rtol = 1e-3)
-    @test stats.status == :first_order
-  =#
+
   stats = fps_solve(
     nlp,
     nlp.meta.x0,
-    σ_0 = 1e3,
-    ρ_0 = 1e3,
-    δ_0 = 1e-2,
-    hessian_approx = Val(2), #error with hessian_approx = 1
-    rtol = 1e-3,
+    hessian_approx = Val(1),
   )
   @test stats.status == :first_order
-  finalize(nlp)
+
+  stats = fps_solve(
+    nlp,
+    nlp.meta.x0,
+    σ_0 = 1e3, # See, https://github.com/tmigot/FletcherPenaltyNLPSolver/issues/24
+    hessian_approx = Val(2),
+  )
+  @test stats.status == :first_order
 end
 
 #=

--- a/test/test-2.jl
+++ b/test/test-2.jl
@@ -259,3 +259,33 @@ end
   @test primal < 1e-6 * max(norm(nlp.meta.x0), 1.0)
   @test status == :first_order
 end
+
+#=
+CUTEst FLT problem
+=#
+@testset "Example problem with unbounded Lagrange estimate" begin
+  nlp = ADNLPModel(
+    x -> (x[2] - 1)^2,
+    [1.0, 0.0],
+    x -> [x[1]^2, x[1]^3],
+    zeros(2),
+    zeros(2),
+    name = "FLT",
+  )
+
+  stats = with_logger(NullLogger()) do
+    fps_solve(nlp, nlp.meta.x0, hessian_approx = Val(1))
+  end
+  dual, primal, status = stats.dual_feas, stats.primal_feas, stats.status
+  @test dual < 1e-6 * max(norm(nlp.meta.x0), 1.0)
+  @test primal < 1e-6 * max(norm(nlp.meta.x0), 1.0)
+  @test status == :first_order
+
+  stats = with_logger(NullLogger()) do
+    fps_solve(nlp, nlp.meta.x0, hessian_approx = Val(2))
+  end
+  dual, primal, status = stats.dual_feas, stats.primal_feas, stats.status
+  @test dual < 1e-6 * max(norm(nlp.meta.x0), 1.0)
+  @test primal < 1e-6 * max(norm(nlp.meta.x0), 1.0)
+  @test status == :first_order
+end


### PR DESCRIPTION
Two aims:
- Increase `δ` (use FLT in unit test)
- ~~Add a subproblem stopping criterion when `y` is unbounded.~~